### PR TITLE
Test: add test for model graph validator

### DIFF
--- a/app/src/test/java/javaroke/graph/DirectedGraphTest.java
+++ b/app/src/test/java/javaroke/graph/DirectedGraphTest.java
@@ -1,0 +1,63 @@
+package javaroke.graph;
+
+import javaroke.models.Edge;
+import javaroke.models.NodeGraph;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DirectedGraphTest {
+
+  @Test
+  public void testAddEdge() {
+    DirectedGraph graph = new DirectedGraph();
+
+    // Add edges
+    graph.addEdge("A", "B", 5);
+    graph.addEdge("A", "C", 3);
+    graph.addEdge("B", "C", 2);
+
+    // Verify adjacency list
+    NodeGraph nodeA = graph.adjacencyList.get("A");
+    NodeGraph nodeB = graph.adjacencyList.get("B");
+    NodeGraph nodeC = graph.adjacencyList.get("C");
+
+    assertNotNull(nodeA);
+    assertNotNull(nodeB);
+    assertNotNull(nodeC);
+
+    assertEquals(2, nodeA.getEdges().size());
+    assertEquals(1, nodeB.getEdges().size());
+    assertEquals(0, nodeC.getEdges().size());
+
+    // Verify edges
+    Edge edgeAB = nodeA.getEdges().stream().filter(edge -> edge.getDestination().equals("B"))
+        .findFirst().orElse(null);
+    assertNotNull(edgeAB);
+    assertEquals(5, edgeAB.getWeight());
+
+    Edge edgeAC = nodeA.getEdges().stream().filter(edge -> edge.getDestination().equals("C"))
+        .findFirst().orElse(null);
+    assertNotNull(edgeAC);
+    assertEquals(3, edgeAC.getWeight());
+
+    Edge edgeBC = nodeB.getEdges().stream().filter(edge -> edge.getDestination().equals("C"))
+        .findFirst().orElse(null);
+    assertNotNull(edgeBC);
+    assertEquals(2, edgeBC.getWeight());
+  }
+
+  @Test
+  public void testShowAdjacencyMatrix() {
+    DirectedGraph graph = new DirectedGraph();
+
+    // Add edges
+    graph.addEdge("A", "B", 5);
+    graph.addEdge("A", "C", 3);
+    graph.addEdge("B", "C", 2);
+
+    // Capture adjacency matrix output
+    graph.showAdjacencyMatric();
+    // Note: You can redirect System.out to capture the printed matrix if needed for assertions.
+  }
+}

--- a/app/src/test/java/javaroke/graph/GraphAbstractTest.java
+++ b/app/src/test/java/javaroke/graph/GraphAbstractTest.java
@@ -1,0 +1,51 @@
+package javaroke.graph;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import javaroke.models.Edge;
+
+public class GraphAbstractTest {
+
+  // A concrete implementation of GraphAbstract for testing
+  private static class TestGraph extends GraphAbstract {
+    @Override
+    public void addEdge(String source, String destination, int weight) {
+      addNode(source);
+      addNode(destination);
+      adjacencyList.get(source).addEdge(new Edge(destination, weight));
+    }
+  }
+
+  @Test
+  public void testAddNode() {
+    GraphAbstract graph = new TestGraph();
+    graph.addNode("A");
+    graph.addNode("B");
+
+    assertEquals(2, graph.numVertices);
+    assertTrue(graph.adjacencyList.containsKey("A"));
+    assertTrue(graph.adjacencyList.containsKey("B"));
+    assertTrue(graph.idList.contains("A"));
+    assertTrue(graph.idList.contains("B"));
+  }
+
+  @Test
+  public void testAddEdge() {
+    GraphAbstract graph = new TestGraph();
+    graph.addEdge("A", "B", 5);
+
+    assertEquals(2, graph.numVertices);
+    assertTrue(graph.adjacencyList.get("A").getEdges().stream()
+        .anyMatch(edge -> edge.getDestination().equals("B") && edge.getWeight() == 5));
+  }
+
+  @Test
+  public void testShowAdjacencyMatrix() {
+    GraphAbstract graph = new TestGraph();
+    graph.addEdge("A", "B", 5);
+    graph.addEdge("B", "C", 3);
+
+    // Redirect output to verify adjacency matrix
+    graph.showAdjacencyMatric();
+  }
+}

--- a/app/src/test/java/javaroke/models/EdgeTest.java
+++ b/app/src/test/java/javaroke/models/EdgeTest.java
@@ -1,0 +1,34 @@
+package javaroke.models;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class EdgeTest {
+  @Test
+  public void testConstructorAndGetters() {
+    Edge edge = new Edge("destination1", 10);
+    assertEquals("destination1", edge.getDestination());
+    assertEquals(10, edge.getWeight());
+  }
+
+  @Test
+  public void testSetDestination() {
+    Edge edge = new Edge("destination1", 10);
+    edge.setDestination("destination2");
+    assertEquals("destination2", edge.getDestination());
+  }
+
+  @Test
+  public void testSetWeight() {
+    Edge edge = new Edge("destination1", 10);
+    edge.setWeight(20);
+    assertEquals(20, edge.getWeight());
+  }
+
+  @Test
+  public void testPlusWeight() {
+    Edge edge = new Edge("destination1", 10);
+    edge.plusWeight(5);
+    assertEquals(15, edge.getWeight());
+  }
+}

--- a/app/src/test/java/javaroke/models/NodeGrapTest.java
+++ b/app/src/test/java/javaroke/models/NodeGrapTest.java
@@ -1,0 +1,79 @@
+package javaroke.models;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NodeGrapTest {
+
+  @Test
+  public void testConstructor() {
+    NodeGraph node = new NodeGraph("song123");
+    assertEquals("song123", node.getSongID());
+    assertTrue(node.getEdges().isEmpty());
+    assertFalse(node.isVisited());
+    assertEquals(Integer.MAX_VALUE, node.getDistance());
+  }
+
+  @Test
+  public void testSetSongID() {
+    NodeGraph node = new NodeGraph("song123");
+    node.setSongID("song456");
+    assertEquals("song456", node.getSongID());
+  }
+
+  @Test
+  public void testSetEdges() {
+    NodeGraph node = new NodeGraph("song123");
+    List<Edge> edges = new ArrayList<>();
+    edges.add(new Edge("song456", 10));
+    node.setEdges(edges);
+    assertEquals(1, node.getEdges().size());
+    assertEquals("song456", node.getEdges().get(0).getDestination());
+  }
+
+  @Test
+  public void testSetVisited() {
+    NodeGraph node = new NodeGraph("song123");
+    node.setVisited(true);
+    assertTrue(node.isVisited());
+  }
+
+  @Test
+  public void testSetDistance() {
+    NodeGraph node = new NodeGraph("song123");
+    node.setDistance(50);
+    assertEquals(50, node.getDistance());
+  }
+
+  @Test
+  public void testPlusDistance() {
+    NodeGraph node = new NodeGraph("song123");
+    node.setDistance(50);
+    node.plusDistance(20);
+    assertEquals(70, node.getDistance());
+  }
+
+  @Test
+  public void testAddEdge_NewEdge() {
+    NodeGraph node = new NodeGraph("song123");
+    Edge edge = new Edge("song456", 10);
+    node.addEdge(edge);
+    assertEquals(1, node.getEdges().size());
+    assertEquals("song456", node.getEdges().get(0).getDestination());
+    assertEquals(10, node.getEdges().get(0).getWeight());
+  }
+
+  @Test
+  public void testAddEdge_ExistingEdge() {
+    NodeGraph node = new NodeGraph("song123");
+    Edge edge1 = new Edge("song456", 10);
+    Edge edge2 = new Edge("song456", 5);
+    node.addEdge(edge1);
+    node.addEdge(edge2);
+    assertEquals(1, node.getEdges().size());
+    assertEquals("song456", node.getEdges().get(0).getDestination());
+    assertEquals(15, node.getEdges().get(0).getWeight());
+  }
+}

--- a/app/src/test/java/javaroke/models/NodeGraphTest.java
+++ b/app/src/test/java/javaroke/models/NodeGraphTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public class NodeGrapTest {
+public class NodeGraphTest {
 
   @Test
   public void testConstructor() {

--- a/app/src/test/java/javaroke/models/NodeLyricTest.java
+++ b/app/src/test/java/javaroke/models/NodeLyricTest.java
@@ -1,0 +1,39 @@
+package javaroke.models;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class NodeLyricTest {
+
+  @Test
+  public void testConstructorAndGetters() {
+    NodeLyric nodeLyric = new NodeLyric("01:23", "Hello World");
+    assertEquals(83, nodeLyric.getTime());
+    assertEquals("Hello World", nodeLyric.getline());
+  }
+
+  @Test
+  public void testSetTime() {
+    NodeLyric nodeLyric = new NodeLyric("01:23", "Hello World");
+    nodeLyric.setTime("02:34");
+    assertEquals(154, nodeLyric.getTime());
+  }
+
+  @Test
+  public void testSetLine() {
+    NodeLyric nodeLyric = new NodeLyric("01:23", "Hello World");
+    nodeLyric.setLine("New Line");
+    assertEquals("New Line", nodeLyric.getline());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidTimeFormatInConstructor() {
+    new NodeLyric("invalid_time", "Hello World");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidTimeFormatInSetTime() {
+    NodeLyric nodeLyric = new NodeLyric("01:23", "Hello World");
+    nodeLyric.setTime("invalid_time");
+  }
+}

--- a/app/src/test/java/javaroke/models/NodeSongTest.java
+++ b/app/src/test/java/javaroke/models/NodeSongTest.java
@@ -1,0 +1,54 @@
+package javaroke.models;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class NodeSongTest {
+
+  @Test
+  public void testConstructorAndGetters() {
+    NodeSong song = new NodeSong("123", "Test Title", "Test Artist", "03:45");
+    assertEquals("123", song.getSongId());
+    assertEquals("Test Title", song.getTitle());
+    assertEquals("Test Artist", song.getArtist());
+    assertEquals(225, song.getDuration());
+  }
+
+  @Test
+  public void testSetSongId() {
+    NodeSong song = new NodeSong("123", "Test Title", "Test Artist", "03:45");
+    song.setSongId("456");
+    assertEquals("456", song.getSongId());
+  }
+
+  @Test
+  public void testSetTitle() {
+    NodeSong song = new NodeSong("123", "Test Title", "Test Artist", "03:45");
+    song.setTitle("New Title");
+    assertEquals("New Title", song.getTitle());
+  }
+
+  @Test
+  public void testSetArtist() {
+    NodeSong song = new NodeSong("123", "Test Title", "Test Artist", "03:45");
+    song.setArtist("New Artist");
+    assertEquals("New Artist", song.getArtist());
+  }
+
+  @Test
+  public void testSetDuration() {
+    NodeSong song = new NodeSong("123", "Test Title", "Test Artist", "03:45");
+    song.setDuration("04:30");
+    assertEquals(270, song.getDuration());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidSongId() {
+    new NodeSong("", "Test Title", "Test Artist", "03:45");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidDuration() {
+    new NodeSong("123", "Test Title", "Test Artist", "invalid");
+  }
+}

--- a/app/src/test/java/javaroke/models/NodeTest.java
+++ b/app/src/test/java/javaroke/models/NodeTest.java
@@ -1,0 +1,42 @@
+package javaroke.models;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class NodeTest {
+  @Test
+  public void testNodeInitialization() {
+    Node<String> node = new Node<>("TestData");
+    assertEquals("TestData", node.getData());
+    assertNull(node.getNext());
+  }
+
+  @Test
+  public void testSetData() {
+    Node<String> node = new Node<>("InitialData");
+    node.setData("UpdatedData");
+    assertEquals("UpdatedData", node.getData());
+  }
+
+  @Test
+  public void testSetNext() {
+    Node<String> node1 = new Node<>("Node1");
+    Node<String> node2 = new Node<>("Node2");
+    node1.setNext(node2);
+    assertEquals(node2, node1.getNext());
+  }
+
+  @Test
+  public void testChainedNodes() {
+    Node<String> node1 = new Node<>("Node1");
+    Node<String> node2 = new Node<>("Node2");
+    Node<String> node3 = new Node<>("Node3");
+
+    node1.setNext(node2);
+    node2.setNext(node3);
+
+    assertEquals(node2, node1.getNext());
+    assertEquals(node3, node2.getNext());
+    assertNull(node3.getNext());
+  }
+}

--- a/app/src/test/java/javaroke/queue/QueueAbstractTest.java
+++ b/app/src/test/java/javaroke/queue/QueueAbstractTest.java
@@ -1,9 +1,8 @@
-package javaroke;
+package javaroke.queue;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-import javaroke.queue.QueueAbstract;
 
 public class QueueAbstractTest {
   @Test

--- a/app/src/test/java/javaroke/queue/QueueLyricTest.java
+++ b/app/src/test/java/javaroke/queue/QueueLyricTest.java
@@ -1,9 +1,7 @@
-package javaroke;
+package javaroke.queue;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
-
-import javaroke.queue.QueueLyric;
 
 public class QueueLyricTest {
   @Test

--- a/app/src/test/java/javaroke/queue/QueueSongTest.java
+++ b/app/src/test/java/javaroke/queue/QueueSongTest.java
@@ -1,9 +1,7 @@
-package javaroke;
+package javaroke.queue;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
-
-import javaroke.queue.QueueSong;
 
 public class QueueSongTest {
   @Test

--- a/app/src/test/java/javaroke/validator/ValidatorTest.java
+++ b/app/src/test/java/javaroke/validator/ValidatorTest.java
@@ -1,0 +1,26 @@
+package javaroke.validator;
+
+import org.junit.Test;
+import javaroke.utils.Validator;
+
+public class ValidatorTest {
+  @Test
+  public void testValidateSongId_validId() {
+    Validator.validateSongId("validSongId123");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateSongId_invalidId() {
+    Validator.validateSongId("invalid song id");
+  }
+
+  @Test
+  public void testValidateTimeForm_validTime() {
+    Validator.validateTimeForm("03:45");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateTimeForm_invalidTime() {
+    Validator.validateTimeForm("345");
+  }
+}


### PR DESCRIPTION
This pull request introduces unit tests for various components of the `javaroke` application, including graph structures, models, queues, and utility validators. It also includes a minor package restructuring for queue-related test files. Below is a summary of the most important changes:

### New Unit Tests for Graph Components
* Added `DirectedGraphTest` to validate edge addition and adjacency matrix functionality in the `DirectedGraph` class.
* Added `GraphAbstractTest` to test the `addNode`, `addEdge`, and adjacency matrix display functionality in a concrete implementation of `GraphAbstract`.

### New Unit Tests for Models
* Added `EdgeTest` to test constructors, getters, setters, and weight modification methods in the `Edge` class.
* Added `NodeGrapTest` to test node attributes, edge management, and distance/visited status in the `NodeGraph` class.
* Added `NodeLyricTest` to test time parsing, line management, and invalid input handling in the `NodeLyric` class.
* Added `NodeSongTest` to test song metadata, duration parsing, and invalid input handling in the `NodeSong` class.
* Added `NodeTest` to test generic node data, chaining, and next-node management in the `Node` class.

### Package Restructuring for Queue Tests
* Renamed and updated the package declaration for `QueueAbstractTest`, `QueueLyricTest`, and `QueueSongTest` to `javaroke.queue` for consistency. [[1]](diffhunk://#diff-36b8a73f433b1bae1c44e2cdd7428efe8529e0235889e2f6457bc184dda575d8L1-L6) [[2]](diffhunk://#diff-5510e723cd6b60519c0226dc48a92359c0513601ef8d6314cd245bee1e8e7ce2L1-L7) [[3]](diffhunk://#diff-86ec9fdd0c7171078d27cdd20f9ef8ae74b9b7dc2b36845bb8b4f8b7bd1b868bL1-L7)

### New Unit Tests for Validators
* Added `ValidatorTest` to test the `Validator` utility for validating song IDs and time formats, including handling of invalid inputs.